### PR TITLE
Add tearDown to clean up coroutine dispatcher

### DIFF
--- a/app/src/test/java/com/rafaellsdev/cryptocurrencyprices/feature/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/rafaellsdev/cryptocurrencyprices/feature/home/HomeViewModelTest.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.resetMain
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -78,5 +80,11 @@ class HomeViewModelTest {
             assert(this.allValues[0] is HomeViewState.Loading)
             assert(this.allValues[1] is HomeViewState.Failure)
         }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        testDispatcher.cleanupTestCoroutines()
     }
 }


### PR DESCRIPTION
## Summary
- add `tearDown` with `@After` to reset the main dispatcher and clean up the test dispatcher

## Testing
- `./gradlew test --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684073f093388327acc93f24e7bd3d92