### PR TITLE
Add dark mode support

### DIFF
--- a/app/src/main/res/drawable/bottom_sheet_rounded_background.xml
+++ b/app/src/main/res/drawable/bottom_sheet_rounded_background.xml
@@ -10,5 +10,5 @@
         android:left="0dp"
         android:right="0dp"
         android:top="0dp" />
-    <solid android:color="@color/white" />
+    <solid android:color="?attr/colorSurface" />
 </shape>

--- a/app/src/main/res/layout/currency_header.xml
+++ b/app/src/main/res/layout/currency_header.xml
@@ -9,7 +9,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="0dp"
         android:layout_height="72dp"
-        android:background="@color/white"
+        android:background="?attr/colorSurface"
         app:layout_constraintBottom_toTopOf="@id/toolbar_shadow"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,5 @@
+<resources>
+    <color name="dark_gray">#FFFFFF</color>
+    <color name="gray">#444444</color>
+    <color name="medium_gray">#BBBBBB</color>
+</resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.CryptocurrencyPrices" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
+    <style name="Theme.CryptocurrencyPrices" parent="Theme.MaterialComponents.DayNight.NoActionBar.Bridge">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/primary_brand_color</item>
         <item name="colorPrimaryVariant">@color/primary_brand_color</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.CryptocurrencyPrices" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
+    <style name="Theme.CryptocurrencyPrices" parent="Theme.MaterialComponents.DayNight.NoActionBar.Bridge">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/primary_brand_color</item>
         <item name="colorPrimaryVariant">@color/primary_brand_color</item>


### PR DESCRIPTION
## Summary
- use Material DayNight theme for the app
- override surface color for header and bottom sheet
- add night colors

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68408de2e9d48327a498040ad941dc3f