### PR TITLE
Add historical price charts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,9 @@ dependencies {
 
     implementation "androidx.navigation:navigation-compose:2.5.3"
 
+    // Chart library
+    implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
+
 
     testImplementation 'junit:junit:4.+'
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.1"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.rafaellsdev.cryptocurrencyprices.feature.home.view.activities.PriceChartActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CurrencyRepository.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CurrencyRepository.kt
@@ -4,4 +4,5 @@ import com.rafaellsdev.cryptocurrencyprices.commons.model.Currency
 
 interface CurrencyRepository {
     suspend fun discoverCurrencies(): List<Currency>
+    suspend fun getMarketChart(id: String, days: Int): List<Pair<Long, Double>>
 }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CurrencyRepositoryImp.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CurrencyRepositoryImp.kt
@@ -15,4 +15,9 @@ class CurrencyRepositoryImp @Inject constructor(
             discoverService.discoverCurrencies()
                 .toCurrencyList()
         }
+
+    override suspend fun getMarketChart(id: String, days: Int): List<Pair<Long, Double>> =
+        withContext(Dispatchers.IO) {
+            discoverService.getMarketChart(id, days = days).toPriceList()
+        }
 }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/mapper/MarketChartMapper.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/mapper/MarketChartMapper.kt
@@ -1,0 +1,6 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.home.repository.mapper
+
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.model.MarketChartResponse
+
+fun MarketChartResponse.toPriceList(): List<Pair<Long, Double>> =
+    prices.map { (time, price) -> time.toLong() to price }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/model/MarketChartResponse.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/model/MarketChartResponse.kt
@@ -1,0 +1,7 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.home.repository.model
+
+import com.google.gson.annotations.SerializedName
+
+data class MarketChartResponse(
+    val prices: List<List<Double>>
+)

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/service/DiscoverService.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/service/DiscoverService.kt
@@ -14,4 +14,11 @@ interface DiscoverService {
         @Query("page") page: Int = 1,
         @Query("sparkline") sparkline: Boolean = false
     ): List<CurrencyResponse>
+
+    @GET("coins/{id}/market_chart")
+    suspend fun getMarketChart(
+        @Path("id") id: String,
+        @Query("vs_currency") currency: String = "eur",
+        @Query("days") days: Int
+    ): MarketChartResponse
 }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/view/activities/HomeActivity.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/view/activities/HomeActivity.kt
@@ -6,6 +6,7 @@ import android.view.View.VISIBLE
 import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
+import android.content.Intent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -16,6 +17,7 @@ import com.rafaellsdev.cryptocurrencyprices.databinding.HomeActivityBinding
 import com.rafaellsdev.cryptocurrencyprices.feature.home.view.adapters.CurrenciesAdapter
 import com.rafaellsdev.cryptocurrencyprices.feature.home.view.components.CurrencyDetailsBottomSheet
 import com.rafaellsdev.cryptocurrencyprices.feature.home.view.components.ErrorView
+import com.rafaellsdev.cryptocurrencyprices.feature.home.view.activities.PriceChartActivity
 import com.rafaellsdev.cryptocurrencyprices.R
 import com.rafaellsdev.cryptocurrencyprices.feature.home.view.state.HomeViewState
 import com.rafaellsdev.cryptocurrencyprices.feature.home.view.model.SortOption
@@ -175,6 +177,14 @@ class HomeActivity : AppCompatActivity(), ErrorView.ErrorListener {
         return CurrencyDetailsBottomSheet.createDialog(
             this,
             dismissAction = ::hideBottomSheet,
+            showChartAction = {
+                startActivity(
+                    Intent(this, PriceChartActivity::class.java).apply {
+                        putExtra(PriceChartActivity.EXTRA_ID, currency.id)
+                        putExtra(PriceChartActivity.EXTRA_NAME, currency.name)
+                    }
+                )
+            },
             fullExpand = false,
             currency = currency
         )

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/view/activities/PriceChartActivity.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/view/activities/PriceChartActivity.kt
@@ -1,0 +1,71 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.home.view.activities
+
+import android.os.Bundle
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import com.github.mikephil.charting.data.Entry
+import com.github.mikephil.charting.data.LineData
+import com.github.mikephil.charting.data.LineDataSet
+import com.rafaellsdev.cryptocurrencyprices.R
+import com.rafaellsdev.cryptocurrencyprices.databinding.PriceChartActivityBinding
+import com.rafaellsdev.cryptocurrencyprices.feature.home.viewmodel.PriceChartViewModel
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class PriceChartActivity : AppCompatActivity() {
+
+    private val binding by lazy { PriceChartActivityBinding.inflate(layoutInflater) }
+    private val viewModel: PriceChartViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+
+        val id = intent.getStringExtra(EXTRA_ID) ?: return finish()
+        title = intent.getStringExtra(EXTRA_NAME) ?: ""
+
+        setupSpinner(id)
+        observeChartData()
+        viewModel.loadChart(id, 1)
+    }
+
+    private fun setupSpinner(id: String) {
+        ArrayAdapter.createFromResource(
+            this,
+            R.array.chart_periods,
+            android.R.layout.simple_spinner_item
+        ).also { adapter ->
+            adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            binding.spinnerPeriod.adapter = adapter
+        }
+        binding.spinnerPeriod.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>, view: android.view.View?, position: Int, idView: Long) {
+                val days = when (position) {
+                    1 -> 7
+                    2 -> 30
+                    else -> 1
+                }
+                viewModel.loadChart(id, days)
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>) {}
+        }
+    }
+
+    private fun observeChartData() {
+        viewModel.chartData.observe(this) { list ->
+            val entries = list.map { Entry(it.first.toFloat(), it.second.toFloat()) }
+            val dataSet = LineDataSet(entries, title)
+            val lineData = LineData(dataSet)
+            binding.lineChart.data = lineData
+            binding.lineChart.invalidate()
+        }
+    }
+
+    companion object {
+        const val EXTRA_ID = "extra_id"
+        const val EXTRA_NAME = "extra_name"
+    }
+}

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/view/components/CurrencyDetailsBottomSheet.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/view/components/CurrencyDetailsBottomSheet.kt
@@ -22,12 +22,13 @@ class CurrencyDetailsBottomSheet private constructor() {
         fun createDialog(
             context: Context,
             dismissAction: () -> Unit,
+            showChartAction: () -> Unit,
             fullExpand: Boolean = false,
             currency: Currency? = null
         ): BottomSheetDialog {
 
             val contentView = CurrencyDetailsBottomSheetView(context).apply {
-                configure(dismissAction, fullExpand, currency)
+                configure(dismissAction, showChartAction, fullExpand, currency)
             }
 
             val dialog = BottomSheetDialog(context)
@@ -60,10 +61,12 @@ private class CurrencyDetailsBottomSheetView @JvmOverloads constructor(
 
     fun configure(
         dismissAction: () -> Unit,
+        showChartAction: () -> Unit,
         fullExpand: Boolean = false,
         currency: Currency?
     ) {
         binding.imgClose.onClick(dismissAction)
+        binding.btnShowChart.onClick(showChartAction)
         binding.bottomSheetCurrencyName.text = currency?.name ?: ""
         binding.bottomSheetPriceValue.text = formatPrice(currency?.currentPrice)
         binding.bottomSheetHighestPriceValue.text = formatPrice(currency?.highPrice)

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/viewmodel/PriceChartViewModel.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/viewmodel/PriceChartViewModel.kt
@@ -1,0 +1,29 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.home.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.rafaellsdev.cryptocurrencyprices.commons.ext.emit
+import com.rafaellsdev.cryptocurrencyprices.commons.ext.safeLaunch
+import com.rafaellsdev.cryptocurrencyprices.commons.model.DefaultError
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.CurrencyRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class PriceChartViewModel @Inject constructor(
+    private val currencyRepository: CurrencyRepository
+) : ViewModel() {
+
+    private val mutableChartData = MutableLiveData<List<Pair<Long, Double>>>()
+    val chartData: LiveData<List<Pair<Long, Double>>> = mutableChartData
+
+    fun loadChart(currencyId: String, days: Int) = safeLaunch(::handleError) {
+        val data = currencyRepository.getMarketChart(currencyId, days)
+        mutableChartData.emit(data)
+    }
+
+    private fun handleError(error: DefaultError) {
+        // no-op for simplicity
+    }
+}

--- a/app/src/main/res/layout/currency_details_bottom_sheet.xml
+++ b/app/src/main/res/layout/currency_details_bottom_sheet.xml
@@ -111,4 +111,14 @@
         app:layout_constraintTop_toBottomOf="@+id/bottom_sheet_highest_price_value"
         tools:text="Lowest price" />
 
+    <Button
+        android:id="@+id/btn_show_chart"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/show_chart"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toBottomOf="@id/bottom_sheet_lowest_price_value"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/price_chart_activity.xml
+++ b/app/src/main/res/layout/price_chart_activity.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Spinner
+        android:id="@+id/spinner_period"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.github.mikephil.charting.charts.LineChart
+        android:id="@+id/line_chart"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_margin="16dp"
+        app:layout_constraintTop_toBottomOf="@id/spinner_period"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -15,6 +15,12 @@
     <string name="error_title_whoops">\u00a1Vaya!</string>
     <string name="error_message_generic">Ha ocurrido un error.</string>
     <string name="error_button_try_again">Intentar de nuevo</string>
+    <string name="show_chart">Mostrar gráfica</string>
+    <string-array name="chart_periods">
+        <item>24h</item>
+        <item>7d</item>
+        <item>30d</item>
+    </string-array>
     <string-array name="sort_options">
         <item>Capitalización de mercado</item>
         <item>Precio</item>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -15,6 +15,12 @@
     <string name="error_title_whoops">Ops!</string>
     <string name="error_message_generic">Ocorreu um erro.</string>
     <string name="error_button_try_again">Tentar novamente</string>
+    <string name="show_chart">Mostrar gráfico</string>
+    <string-array name="chart_periods">
+        <item>24h</item>
+        <item>7d</item>
+        <item>30d</item>
+    </string-array>
     <string-array name="sort_options">
         <item>Valor de mercado</item>
         <item>Preço</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,12 @@
     <string name="error_title_whoops">Whoops!</string>
     <string name="error_message_generic">We have an error.</string>
     <string name="error_button_try_again">Try again</string>
+    <string name="show_chart">Show Chart</string>
+    <string-array name="chart_periods">
+        <item>24h</item>
+        <item>7d</item>
+        <item>30d</item>
+    </string-array>
     <string-array name="sort_options">
         <item>Market Cap</item>
         <item>Price</item>


### PR DESCRIPTION
## Summary
- integrate MPAndroidChart for line charting
- fetch historical market chart data from the API
- create `PriceChartActivity` and `PriceChartViewModel`
- add "Show Chart" button in currency details bottom sheet
- wire new activity from `HomeActivity`
- add translations for chart strings

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68409385f7308327b11b39fae43b562a