### PR TITLE
Add coin category filtering

### DIFF
--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/const/URLs.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/const/URLs.kt
@@ -2,5 +2,6 @@ package com.rafaellsdev.cryptocurrencyprices.commons.const
 
 object URLs {
     const val CURRENCIES_SERVICE = "coins/markets"
+    const val COIN_CATEGORIES_SERVICE = "coins/categories"
     const val BASE_URL = "https://api.coingecko.com/api/v3/"
 }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/model/Category.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/model/Category.kt
@@ -1,0 +1,6 @@
+package com.rafaellsdev.cryptocurrencyprices.commons.model
+
+data class Category(
+    val id: String,
+    val name: String
+)

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/di/DataModule.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/di/DataModule.kt
@@ -3,6 +3,8 @@ package com.rafaellsdev.cryptocurrencyprices.di
 import com.rafaellsdev.cryptocurrencyprices.commons.const.URLs.BASE_URL
 import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.CurrencyRepository
 import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.CurrencyRepositoryImp
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.CategoryRepository
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.CategoryRepositoryImp
 import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.service.DiscoverService
 import com.rafaellsdev.cryptocurrencyprices.commons.currency.CurrencyPreferenceRepository
 import com.rafaellsdev.cryptocurrencyprices.commons.currency.CurrencyPreferenceRepositoryImp
@@ -46,6 +48,13 @@ object DataModule {
         currencyPreferenceRepository: CurrencyPreferenceRepository
     ): CurrencyRepository =
         CurrencyRepositoryImp(discoverService, currencyPreferenceRepository)
+
+    @Singleton
+    @Provides
+    fun provideCategoryRepository(
+        discoverService: DiscoverService
+    ): CategoryRepository =
+        CategoryRepositoryImp(discoverService)
 
     @Singleton
     @Provides

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CategoryRepository.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CategoryRepository.kt
@@ -1,0 +1,7 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.home.repository
+
+import com.rafaellsdev.cryptocurrencyprices.commons.model.Category
+
+interface CategoryRepository {
+    suspend fun getCategories(): List<Category>
+}

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CategoryRepositoryImp.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CategoryRepositoryImp.kt
@@ -1,0 +1,16 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.home.repository
+
+import com.rafaellsdev.cryptocurrencyprices.commons.model.Category
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.mapper.toCategoryList
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.service.DiscoverService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class CategoryRepositoryImp @Inject constructor(
+    private val discoverService: DiscoverService
+) : CategoryRepository {
+    override suspend fun getCategories(): List<Category> = withContext(Dispatchers.IO) {
+        discoverService.getCategories().toCategoryList()
+    }
+}

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CurrencyRepository.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CurrencyRepository.kt
@@ -3,5 +3,5 @@ package com.rafaellsdev.cryptocurrencyprices.feature.home.repository
 import com.rafaellsdev.cryptocurrencyprices.commons.model.Currency
 
 interface CurrencyRepository {
-    suspend fun discoverCurrencies(): List<Currency>
+    suspend fun discoverCurrencies(category: String? = null): List<Currency>
 }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CurrencyRepositoryImp.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CurrencyRepositoryImp.kt
@@ -12,10 +12,10 @@ class CurrencyRepositoryImp @Inject constructor(
     private val discoverService: DiscoverService,
     private val currencyPreferenceRepository: CurrencyPreferenceRepository
 ) : CurrencyRepository {
-    override suspend fun discoverCurrencies(): List<Currency> =
+    override suspend fun discoverCurrencies(category: String?): List<Currency> =
         withContext(Dispatchers.IO) {
             val currency = currencyPreferenceRepository.getSelectedCurrency()
-            discoverService.discoverCurrencies(currency = currency)
+            discoverService.discoverCurrencies(currency = currency, category = category)
                 .toCurrencyList()
         }
 }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/mapper/CategoryResponseMapper.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/mapper/CategoryResponseMapper.kt
@@ -1,0 +1,12 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.home.repository.mapper
+
+import com.rafaellsdev.cryptocurrencyprices.commons.model.Category
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.model.CategoryResponse
+
+fun List<CategoryResponse>.toCategoryList() =
+    this.map {
+        Category(
+            id = it.id.orEmpty(),
+            name = it.name.orEmpty()
+        )
+    }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/model/CategoryResponse.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/model/CategoryResponse.kt
@@ -1,0 +1,9 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.home.repository.model
+
+import com.google.gson.annotations.SerializedName
+
+data class CategoryResponse(
+    val id: String?,
+    @SerializedName("name")
+    val name: String?
+)

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/service/DiscoverService.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/service/DiscoverService.kt
@@ -1,7 +1,9 @@
 package com.rafaellsdev.cryptocurrencyprices.feature.home.repository.service
 
 import com.rafaellsdev.cryptocurrencyprices.commons.const.URLs.CURRENCIES_SERVICE
+import com.rafaellsdev.cryptocurrencyprices.commons.const.URLs.COIN_CATEGORIES_SERVICE
 import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.model.CurrencyResponse
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.model.CategoryResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -12,6 +14,10 @@ interface DiscoverService {
         @Query("order") order: String = "market_cap_desc",
         @Query("per_page") maxPerPage: Int = 100,
         @Query("page") page: Int = 1,
-        @Query("sparkline") sparkline: Boolean = false
+        @Query("sparkline") sparkline: Boolean = false,
+        @Query("category") category: String? = null
     ): List<CurrencyResponse>
+
+    @GET(COIN_CATEGORIES_SERVICE)
+    suspend fun getCategories(): List<CategoryResponse>
 }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/view/activities/HomeActivity.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/view/activities/HomeActivity.kt
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.rafaellsdev.cryptocurrencyprices.commons.ext.observe
 import com.rafaellsdev.cryptocurrencyprices.commons.model.Currency
+import com.rafaellsdev.cryptocurrencyprices.commons.model.Category
 import com.rafaellsdev.cryptocurrencyprices.databinding.HomeActivityBinding
 import com.rafaellsdev.cryptocurrencyprices.feature.home.view.adapters.CurrenciesAdapter
 import com.rafaellsdev.cryptocurrencyprices.feature.home.view.components.CurrencyDetailsBottomSheet
@@ -29,6 +30,7 @@ class HomeActivity : AppCompatActivity(), ErrorView.ErrorListener {
     private var currencyDialog: BottomSheetDialog? = null
     private lateinit var currenciesAdapter: CurrenciesAdapter
     private var allCurrencies: List<Currency> = emptyList()
+    private var categories: List<Category> = emptyList()
     private var currentQuery: String? = null
     private var sortOption: SortOption = SortOption.MARKET_CAP
 
@@ -40,8 +42,11 @@ class HomeActivity : AppCompatActivity(), ErrorView.ErrorListener {
         setupSearchView()
         setupSortSpinner()
         setupCurrencySpinner()
+        setupCategorySpinner()
         observeHomeState()
+        observeCategories()
         requestHomeData()
+        viewModel.loadCategories()
     }
 
     private fun setListeners() {
@@ -115,6 +120,29 @@ class HomeActivity : AppCompatActivity(), ErrorView.ErrorListener {
             }
 
             override fun onNothingSelected(parent: AdapterView<*>) {}
+        }
+    }
+
+    private fun setupCategorySpinner() {
+        binding.spinnerCategory.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
+                val selected = if (position == 0) null else categories[position - 1].id
+                viewModel.setSelectedCategory(selected)
+                requestHomeData()
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>) {}
+        }
+    }
+
+    private fun observeCategories() {
+        observe(viewModel.categories) { list ->
+            categories = list
+            val names = mutableListOf(getString(R.string.category_all))
+            names.addAll(list.map { it.name })
+            val adapter = ArrayAdapter(this, android.R.layout.simple_spinner_item, names)
+            adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            binding.spinnerCategory.adapter = adapter
         }
     }
 

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/viewmodel/HomeViewModel.kt
@@ -7,8 +7,10 @@ import com.rafaellsdev.cryptocurrencyprices.commons.ext.emit
 import com.rafaellsdev.cryptocurrencyprices.commons.ext.safeLaunch
 import com.rafaellsdev.cryptocurrencyprices.commons.model.DefaultError
 import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.CurrencyRepository
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.CategoryRepository
 import com.rafaellsdev.cryptocurrencyprices.commons.favorites.FavoritesRepository
 import com.rafaellsdev.cryptocurrencyprices.commons.currency.CurrencyPreferenceRepository
+import com.rafaellsdev.cryptocurrencyprices.commons.model.Category
 import com.rafaellsdev.cryptocurrencyprices.feature.home.view.state.HomeViewState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -17,11 +19,17 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     private val currencyRepository: CurrencyRepository,
     private val favoritesRepository: FavoritesRepository,
-    private val currencyPreferenceRepository: CurrencyPreferenceRepository
+    private val currencyPreferenceRepository: CurrencyPreferenceRepository,
+    private val categoryRepository: CategoryRepository
 ) : ViewModel() {
 
     private val mutableLiveDataState = MutableLiveData<HomeViewState>()
     val homeViewState: LiveData<HomeViewState> = mutableLiveDataState
+
+    private val mutableCategories = MutableLiveData<List<Category>>()
+    val categories: LiveData<List<Category>> = mutableCategories
+
+    private var selectedCategory: String? = null
 
     fun toggleFavorite(id: String) {
         favoritesRepository.toggleFavorite(id)
@@ -38,8 +46,17 @@ class HomeViewModel @Inject constructor(
     fun discoverCurrencies() = safeLaunch(::handleError) {
         mutableLiveDataState.emit(HomeViewState.Loading)
 
-        val currencies = currencyRepository.discoverCurrencies()
+        val currencies = currencyRepository.discoverCurrencies(selectedCategory)
         mutableLiveDataState.emit(HomeViewState.Success(currencies))
+    }
+
+    fun loadCategories() = safeLaunch(::handleError) {
+        val categories = categoryRepository.getCategories()
+        mutableCategories.emit(categories)
+    }
+
+    fun setSelectedCategory(id: String?) {
+        selectedCategory = id
     }
 
     private fun handleError(error: DefaultError) {

--- a/app/src/main/res/layout/home_activity.xml
+++ b/app/src/main/res/layout/home_activity.xml
@@ -97,6 +97,14 @@
             app:layout_constraintStart_toEndOf="@id/spinner_sort"
             app:layout_constraintTop_toBottomOf="@id/search_view" />
 
+        <Spinner
+            android:id="@+id/spinner_category"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            app:layout_constraintStart_toEndOf="@id/spinner_currency"
+            app:layout_constraintTop_toBottomOf="@id/search_view" />
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rcv_currency"
             android:layout_width="match_parent"
@@ -104,7 +112,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/spinner_currency" />
+            app:layout_constraintTop_toBottomOf="@id/spinner_category" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -25,4 +25,5 @@
         <item>EUR</item>
         <item>USD</item>
     </string-array>
+    <string name="category_all">Todas</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -25,4 +25,5 @@
         <item>EUR</item>
         <item>USD</item>
     </string-array>
+    <string name="category_all">Todas</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,4 +25,5 @@
         <item>EUR</item>
         <item>USD</item>
     </string-array>
+    <string name="category_all">All</string>
 </resources>

--- a/app/src/test/java/com/rafaellsdev/cryptocurrencyprices/feature/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/rafaellsdev/cryptocurrencyprices/feature/home/HomeViewModelTest.kt
@@ -6,6 +6,8 @@ import com.nhaarman.mockitokotlin2.verify
 import com.rafaellsdev.cryptocurrencyprices.factory.currencyList
 import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.CurrencyRepository
 import com.rafaellsdev.cryptocurrencyprices.commons.favorites.FavoritesRepository
+import com.rafaellsdev.cryptocurrencyprices.commons.currency.CurrencyPreferenceRepository
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.CategoryRepository
 import com.rafaellsdev.cryptocurrencyprices.feature.home.viewmodel.HomeViewModel
 import com.rafaellsdev.cryptocurrencyprices.feature.home.view.state.HomeViewState
 import kotlinx.coroutines.Dispatchers
@@ -42,6 +44,12 @@ class HomeViewModelTest {
     lateinit var favoritesRepository: FavoritesRepository
 
     @Mock
+    lateinit var currencyPreferenceRepository: CurrencyPreferenceRepository
+
+    @Mock
+    lateinit var categoryRepository: CategoryRepository
+
+    @Mock
     lateinit var observer: Observer<HomeViewState>
 
     private lateinit var viewModel: HomeViewModel
@@ -49,7 +57,13 @@ class HomeViewModelTest {
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        viewModel = HomeViewModel(repository, favoritesRepository)
+        Mockito.`when`(currencyPreferenceRepository.getSelectedCurrency()).thenReturn("eur")
+        viewModel = HomeViewModel(
+            repository,
+            favoritesRepository,
+            currencyPreferenceRepository,
+            categoryRepository
+        )
         viewModel.homeViewState.observeForever(observer)
     }
 
@@ -57,7 +71,7 @@ class HomeViewModelTest {
     @Test
     fun whenRequestDiscoverSuccessShouldEmitLoadingThenSuccess() = runBlockingTest {
         // Given
-        Mockito.`when`(repository.discoverCurrencies()).thenReturn(currencyList())
+        Mockito.`when`(repository.discoverCurrencies(null)).thenReturn(currencyList())
 
         // When
         viewModel.discoverCurrencies()
@@ -73,7 +87,7 @@ class HomeViewModelTest {
     @Test
     fun whenRequestDiscoverFailsShouldEmitLoadingThenFailure() = runBlockingTest {
         // Given
-        Mockito.`when`(repository.discoverCurrencies()).thenThrow(RuntimeException())
+        Mockito.`when`(repository.discoverCurrencies(null)).thenThrow(RuntimeException())
 
         // When
         viewModel.discoverCurrencies()


### PR DESCRIPTION
## Summary
- fetch coin categories from CoinGecko via new service call
- support optional category filter when retrieving currency list
- store selected category in view model and expose category list
- provide UI spinner to choose category
- wire up DI and update tests

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6840aa518de8832797afcde8468fb303