### PR TITLE
Add detailed coin stats in bottom sheet

### DIFF
--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/model/Currency.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/model/Currency.kt
@@ -9,5 +9,8 @@ data class Currency(
     val currentPrice: Double,
     val priceChangePercentage: Double,
     val highPrice: Double,
-    val lowPrice: Double
+    val lowPrice: Double,
+    val totalVolume: Double,
+    val circulatingSupply: Double,
+    val totalSupply: Double
 )

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/mapper/DiscoverResponseMapper.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/mapper/DiscoverResponseMapper.kt
@@ -15,6 +15,9 @@ fun List<CurrencyResponse>.toCurrencyList() =
             currentPrice = it.currentPrice.doubleOrZero(),
             priceChangePercentage = it.priceChangePercentage.doubleOrZero(),
             highPrice = it.highPrice.doubleOrZero(),
-            lowPrice = it.lowPrice.doubleOrZero()
+            lowPrice = it.lowPrice.doubleOrZero(),
+            totalVolume = it.totalVolume.doubleOrZero(),
+            circulatingSupply = it.circulatingSupply.doubleOrZero(),
+            totalSupply = it.totalSupply.doubleOrZero()
         )
     }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/model/CurrencyResponse.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/model/CurrencyResponse.kt
@@ -16,5 +16,11 @@ data class CurrencyResponse(
     @SerializedName("high_24h")
     val highPrice: Double?,
     @SerializedName("low_24h")
-    val lowPrice: Double?
+    val lowPrice: Double?,
+    @SerializedName("total_volume")
+    val totalVolume: Double?,
+    @SerializedName("circulating_supply")
+    val circulatingSupply: Double?,
+    @SerializedName("total_supply")
+    val totalSupply: Double?
 )

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/view/components/CurrencyDetailsBottomSheet.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/view/components/CurrencyDetailsBottomSheet.kt
@@ -70,6 +70,9 @@ private class CurrencyDetailsBottomSheetView @JvmOverloads constructor(
         binding.bottomSheetPriceValue.text = formatPrice(currency?.currentPrice, currencyCode)
         binding.bottomSheetHighestPriceValue.text = formatPrice(currency?.highPrice, currencyCode)
         binding.bottomSheetLowestPriceValue.text = formatPrice(currency?.lowPrice, currencyCode)
+        binding.bottomSheetVolumeValue.text = formatPrice(currency?.totalVolume, currencyCode)
+        binding.bottomSheetCirculatingSupplyValue.text = formatNumber(currency?.circulatingSupply)
+        binding.bottomSheetTotalSupplyValue.text = formatNumber(currency?.totalSupply)
 
         setHeight(fullExpand)
     }
@@ -79,6 +82,12 @@ private class CurrencyDetailsBottomSheetView @JvmOverloads constructor(
         format.maximumFractionDigits = 0
         format.currency = getInstance(currencyCode)
         return format.format(price)
+    }
+
+    private fun formatNumber(value: Any?): String {
+        val format: NumberFormat = NumberFormat.getNumberInstance()
+        format.maximumFractionDigits = 0
+        return format.format(value)
     }
 
 

--- a/app/src/main/res/layout/currency_details_bottom_sheet.xml
+++ b/app/src/main/res/layout/currency_details_bottom_sheet.xml
@@ -111,4 +111,61 @@
         app:layout_constraintTop_toBottomOf="@+id/bottom_sheet_highest_price_value"
         tools:text="Lowest price" />
 
+    <TextView
+        android:id="@+id/bottom_sheet_volume"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/daily_volume"
+        android:textColor="@color/dark_gray"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="@+id/bottom_sheet_low_price"
+        app:layout_constraintTop_toBottomOf="@+id/bottom_sheet_low_price" />
+
+    <TextView
+        android:id="@+id/bottom_sheet_volume_value"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        app:layout_constraintStart_toEndOf="@+id/bottom_sheet_volume"
+        app:layout_constraintTop_toTopOf="@+id/bottom_sheet_volume"
+        tools:text="Volume" />
+
+    <TextView
+        android:id="@+id/bottom_sheet_circulating_supply"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/circulating_supply"
+        android:textColor="@color/dark_gray"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="@+id/bottom_sheet_volume"
+        app:layout_constraintTop_toBottomOf="@+id/bottom_sheet_volume" />
+
+    <TextView
+        android:id="@+id/bottom_sheet_circulating_supply_value"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        app:layout_constraintStart_toEndOf="@+id/bottom_sheet_circulating_supply"
+        app:layout_constraintTop_toTopOf="@+id/bottom_sheet_circulating_supply"
+        tools:text="Circulating" />
+
+    <TextView
+        android:id="@+id/bottom_sheet_total_supply"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/total_supply"
+        android:textColor="@color/dark_gray"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="@+id/bottom_sheet_circulating_supply"
+        app:layout_constraintTop_toBottomOf="@+id/bottom_sheet_circulating_supply" />
+
+    <TextView
+        android:id="@+id/bottom_sheet_total_supply_value"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        app:layout_constraintStart_toEndOf="@+id/bottom_sheet_total_supply"
+        app:layout_constraintTop_toTopOf="@+id/bottom_sheet_total_supply"
+        tools:text="Total" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -29,4 +29,7 @@
     <string name="all_categories">Todas</string>
 
     <string name="trending">Tendencias</string>
+    <string name="daily_volume">Volumen diario: </string>
+    <string name="circulating_supply">Suministro en circulación: </string>
+    <string name="total_supply">Suministro total: </string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -29,4 +29,7 @@
     <string name="all_categories">Todas</string>
 
     <string name="trending">Tendências</string>
+    <string name="daily_volume">Volume diário: </string>
+    <string name="circulating_supply">Oferta em circulação: </string>
+    <string name="total_supply">Oferta total: </string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,4 +29,7 @@
     <string name="all_categories">All</string>
 
     <string name="trending">Trending</string>
+    <string name="daily_volume">Daily volume: </string>
+    <string name="circulating_supply">Circulating supply: </string>
+    <string name="total_supply">Total supply: </string>
 </resources>

--- a/app/src/test/java/com/rafaellsdev/cryptocurrencyprices/factory/DataFactory.kt
+++ b/app/src/test/java/com/rafaellsdev/cryptocurrencyprices/factory/DataFactory.kt
@@ -14,7 +14,10 @@ fun currencyList() =
             currentPrice = 42938.0,
             priceChangePercentage = -2.56888,
             highPrice = 44444.0,
-            lowPrice = 42008.0
+            lowPrice = 42008.0,
+            totalVolume = 5000000.0,
+            circulatingSupply = 18000000.0,
+            totalSupply = 21000000.0
         )
     )
 


### PR DESCRIPTION
## Summary
- extend currency model with volume and supply fields
- map new stats from API responses
- show daily volume and supply stats in CurrencyDetailsBottomSheet
- add translated strings for new labels

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6840b3656084832790cfb6c53071cf3d