### PR TITLE
Add basic crypto news feed

### DIFF
--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/const/URLs.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/const/URLs.kt
@@ -3,4 +3,5 @@ package com.rafaellsdev.cryptocurrencyprices.commons.const
 object URLs {
     const val CURRENCIES_SERVICE = "coins/markets"
     const val BASE_URL = "https://api.coingecko.com/api/v3/"
+    const val NEWS_BASE_URL = "https://min-api.cryptocompare.com/data/v2/"
 }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/model/NewsArticle.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/model/NewsArticle.kt
@@ -1,0 +1,12 @@
+package com.rafaellsdev.cryptocurrencyprices.commons.model
+
+/**
+ * Represents a news article from crypto news sources.
+ */
+data class NewsArticle(
+    val id: String,
+    val title: String,
+    val source: String,
+    val url: String,
+    val imageUrl: String
+)

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/di/DataModule.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/di/DataModule.kt
@@ -10,6 +10,10 @@ import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.CategoryRepo
 import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.service.DiscoverService
 import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.service.TrendingService
 import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.service.CategoryService
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.NewsRepository
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.NewsRepositoryImp
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.service.NewsService
+import com.rafaellsdev.cryptocurrencyprices.commons.const.URLs.NEWS_BASE_URL
 import com.rafaellsdev.cryptocurrencyprices.commons.currency.CurrencyPreferenceRepository
 import com.rafaellsdev.cryptocurrencyprices.commons.currency.CurrencyPreferenceRepositoryImp
 import com.rafaellsdev.cryptocurrencyprices.commons.favorites.FavoritesRepository
@@ -77,4 +81,18 @@ object DataModule {
     @Provides
     fun provideFavoritesRepository(preferences: SharedPreferences): FavoritesRepository =
         FavoritesRepositoryImp(preferences)
+
+    @Singleton
+    @Provides
+    fun provideNewsService(): NewsService =
+        Retrofit.Builder()
+            .baseUrl(NEWS_BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(NewsService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideNewsRepository(newsService: NewsService): NewsRepository =
+        NewsRepositoryImp(newsService)
 }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/NewsRepository.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/NewsRepository.kt
@@ -1,0 +1,7 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.home.repository
+
+import com.rafaellsdev.cryptocurrencyprices.commons.model.NewsArticle
+
+interface NewsRepository {
+    suspend fun getNewsArticles(): List<NewsArticle>
+}

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/NewsRepositoryImp.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/NewsRepositoryImp.kt
@@ -1,0 +1,17 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.home.repository
+
+import com.rafaellsdev.cryptocurrencyprices.commons.model.NewsArticle
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.mapper.toNewsArticleList
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.service.NewsService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class NewsRepositoryImp @Inject constructor(
+    private val service: NewsService
+) : NewsRepository {
+    override suspend fun getNewsArticles(): List<NewsArticle> =
+        withContext(Dispatchers.IO) {
+            service.getNews().toNewsArticleList()
+        }
+}

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/mapper/NewsResponseMapper.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/mapper/NewsResponseMapper.kt
@@ -1,0 +1,17 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.home.repository.mapper
+
+import com.rafaellsdev.cryptocurrencyprices.commons.model.NewsArticle
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.model.NewsResponse
+
+fun NewsResponse.toNewsArticleList(): List<NewsArticle> =
+    this.data?.mapNotNull {
+        val id = it.id ?: return@mapNotNull null
+        val title = it.title ?: return@mapNotNull null
+        NewsArticle(
+            id = id,
+            title = title,
+            source = it.sourceName.orEmpty(),
+            url = it.url.orEmpty(),
+            imageUrl = it.imageUrl.orEmpty()
+        )
+    } ?: emptyList()

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/model/NewsResponse.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/model/NewsResponse.kt
@@ -1,0 +1,21 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.home.repository.model
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Response from the CryptoCompare news endpoint.
+ */
+data class NewsResponse(
+    @SerializedName("Data")
+    val data: List<NewsArticleResponse>?
+)
+
+data class NewsArticleResponse(
+    val id: String?,
+    val title: String?,
+    val url: String?,
+    @SerializedName("source")
+    val sourceName: String?,
+    @SerializedName("imageurl")
+    val imageUrl: String?
+)

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/service/NewsService.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/service/NewsService.kt
@@ -1,0 +1,10 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.home.repository.service
+
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.model.NewsResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface NewsService {
+    @GET("news/")
+    suspend fun getNews(@Query("lang") lang: String = "EN"): NewsResponse
+}

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/view/adapters/NewsAdapter.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/view/adapters/NewsAdapter.kt
@@ -1,0 +1,40 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.home.view.adapters
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.rafaellsdev.cryptocurrencyprices.commons.model.NewsArticle
+import com.rafaellsdev.cryptocurrencyprices.databinding.NewsItemBinding
+import com.squareup.picasso.Picasso
+
+class NewsAdapter(
+    private var news: List<NewsArticle>
+) : RecyclerView.Adapter<NewsAdapter.ViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = NewsItemBinding.inflate(
+            LayoutInflater.from(parent.context), parent, false
+        )
+        return ViewHolder(binding)
+    }
+
+    override fun getItemCount(): Int = news.size
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(news[position])
+    }
+
+    fun updateNews(news: List<NewsArticle>) {
+        this.news = news
+        notifyDataSetChanged()
+    }
+
+    inner class ViewHolder(private val binding: NewsItemBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: NewsArticle) {
+            binding.txtNewsTitle.text = item.title
+            binding.txtNewsSource.text = item.source
+            Picasso.get().load(item.imageUrl).into(binding.imgNewsThumbnail)
+        }
+    }
+}

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/view/fragments/FeedFragment.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/view/fragments/FeedFragment.kt
@@ -5,13 +5,19 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.rafaellsdev.cryptocurrencyprices.databinding.FragmentFeedBinding
+import com.rafaellsdev.cryptocurrencyprices.feature.home.view.adapters.NewsAdapter
+import com.rafaellsdev.cryptocurrencyprices.feature.home.viewmodel.FeedViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class FeedFragment : Fragment() {
     private var _binding: FragmentFeedBinding? = null
     private val binding get() = _binding!!
+    private val viewModel: FeedViewModel by viewModels()
+    private lateinit var adapter: NewsAdapter
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -22,8 +28,27 @@ class FeedFragment : Fragment() {
         return binding.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupRecycler()
+        observeNews()
+        viewModel.loadNews()
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun setupRecycler() {
+        adapter = NewsAdapter(emptyList())
+        binding.rcvNews.layoutManager = LinearLayoutManager(requireContext())
+        binding.rcvNews.adapter = adapter
+    }
+
+    private fun observeNews() {
+        viewModel.news.observe(viewLifecycleOwner) {
+            adapter.updateNews(it)
+        }
     }
 }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/viewmodel/FeedViewModel.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/viewmodel/FeedViewModel.kt
@@ -1,0 +1,33 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.home.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.rafaellsdev.cryptocurrencyprices.commons.ext.emit
+import com.rafaellsdev.cryptocurrencyprices.commons.ext.safeLaunch
+import com.rafaellsdev.cryptocurrencyprices.commons.model.DefaultError
+import com.rafaellsdev.cryptocurrencyprices.commons.model.NewsArticle
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.NewsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class FeedViewModel @Inject constructor(
+    private val repository: NewsRepository
+) : ViewModel() {
+
+    private val mutableNews = MutableLiveData<List<NewsArticle>>()
+    val news: LiveData<List<NewsArticle>> = mutableNews
+
+    private val mutableError = MutableLiveData<String>()
+    val error: LiveData<String> = mutableError
+
+    fun loadNews() = safeLaunch(::handleError) {
+        val articles = repository.getNewsArticles()
+        mutableNews.emit(articles)
+    }
+
+    private fun handleError(error: DefaultError) {
+        mutableError.emit(error.errorMessage)
+    }
+}

--- a/app/src/main/res/layout/fragment_feed.xml
+++ b/app/src/main/res/layout/fragment_feed.xml
@@ -13,4 +13,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rcv_news"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:listitem="@layout/news_item" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/news_item.xml
+++ b/app/src/main/res/layout/news_item.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp">
+
+    <ImageView
+        android:id="@+id/img_news_thumbnail"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        android:scaleType="centerCrop"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:src="@drawable/ic_launcher_background" />
+
+    <TextView
+        android:id="@+id/txt_news_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:textColor="@color/dark_gray"
+        android:textStyle="bold"
+        app:layout_constraintStart_toEndOf="@id/img_news_thumbnail"
+        app:layout_constraintTop_toTopOf="@id/img_news_thumbnail"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:text="News title" />
+
+    <TextView
+        android:id="@+id/txt_news_source"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:textColor="@color/dark_gray"
+        android:textSize="12sp"
+        app:layout_constraintStart_toStartOf="@id/txt_news_title"
+        app:layout_constraintTop_toBottomOf="@id/txt_news_title"
+        app:layout_constraintEnd_toEndOf="@id/txt_news_title"
+        tools:text="Source" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@drawable/toolbar_shadow"
+        app:layout_constraintTop_toBottomOf="@id/img_news_thumbnail"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- create `NewsArticle` model
- add NewsRepository and service using CryptoCompare API
- wire news retrieval via Hilt in `DataModule`
- implement `FeedViewModel` and `NewsAdapter`
- update `FeedFragment` and layout to display news list
- add item layout for news entries
- expose NEWS_BASE_URL constant

## Testing
- `./gradlew assembleDebug` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6840bdc1cf488327a2b2dcd3e5a3ddf5