### PR TITLE
Implement offline database cache

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,11 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
     implementation "com.squareup.picasso:picasso:2.71828"
 
+    // Room
+    implementation "androidx.room:room-runtime:$room_version"
+    kapt "androidx.room:room-compiler:$room_version"
+    implementation "androidx.room:room-ktx:$room_version"
+
     // Hilt
     implementation "com.google.dagger:hilt-android:$hilt_version"
     kapt "com.google.dagger:hilt-android-compiler:$hilt_version"

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/local/AppDatabase.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/local/AppDatabase.kt
@@ -1,0 +1,10 @@
+package com.rafaellsdev.cryptocurrencyprices.commons.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(entities = [CurrencyEntity::class, TrendingCoinEntity::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun currencyDao(): CurrencyDao
+    abstract fun trendingCoinDao(): TrendingCoinDao
+}

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/local/CurrencyDao.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/local/CurrencyDao.kt
@@ -1,0 +1,15 @@
+package com.rafaellsdev.cryptocurrencyprices.commons.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface CurrencyDao {
+    @Query("SELECT * FROM currencies")
+    suspend fun getCurrencies(): List<CurrencyEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertCurrencies(currencies: List<CurrencyEntity>)
+}

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/local/CurrencyEntity.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/local/CurrencyEntity.kt
@@ -1,0 +1,51 @@
+package com.rafaellsdev.cryptocurrencyprices.commons.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.rafaellsdev.cryptocurrencyprices.commons.model.Currency
+
+@Entity(tableName = "currencies")
+data class CurrencyEntity(
+    @PrimaryKey val id: String,
+    val symbol: String,
+    val name: String?,
+    val image: String?,
+    val marketCap: Double,
+    val currentPrice: Double,
+    val priceChangePercentage: Double,
+    val highPrice: Double,
+    val lowPrice: Double,
+    val totalVolume: Double,
+    val circulatingSupply: Double,
+    val totalSupply: Double
+)
+
+fun CurrencyEntity.toDomain() = Currency(
+    id = id,
+    symbol = symbol,
+    name = name,
+    image = image,
+    marketCap = marketCap,
+    currentPrice = currentPrice,
+    priceChangePercentage = priceChangePercentage,
+    highPrice = highPrice,
+    lowPrice = lowPrice,
+    totalVolume = totalVolume,
+    circulatingSupply = circulatingSupply,
+    totalSupply = totalSupply
+)
+
+fun Currency.toEntity() = CurrencyEntity(
+    id = id,
+    symbol = symbol,
+    name = name,
+    image = image,
+    marketCap = marketCap,
+    currentPrice = currentPrice,
+    priceChangePercentage = priceChangePercentage,
+    highPrice = highPrice,
+    lowPrice = lowPrice,
+    totalVolume = totalVolume,
+    circulatingSupply = circulatingSupply,
+    totalSupply = totalSupply
+)

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/local/TrendingCoinDao.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/local/TrendingCoinDao.kt
@@ -1,0 +1,15 @@
+package com.rafaellsdev.cryptocurrencyprices.commons.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface TrendingCoinDao {
+    @Query("SELECT * FROM trending_coins")
+    suspend fun getTrendingCoins(): List<TrendingCoinEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertTrendingCoins(coins: List<TrendingCoinEntity>)
+}

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/local/TrendingCoinEntity.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/local/TrendingCoinEntity.kt
@@ -1,0 +1,27 @@
+package com.rafaellsdev.cryptocurrencyprices.commons.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.rafaellsdev.cryptocurrencyprices.commons.model.TrendingCoin
+
+@Entity(tableName = "trending_coins")
+data class TrendingCoinEntity(
+    @PrimaryKey val id: String,
+    val symbol: String,
+    val name: String,
+    val image: String
+)
+
+fun TrendingCoinEntity.toDomain() = TrendingCoin(
+    id = id,
+    symbol = symbol,
+    name = name,
+    image = image
+)
+
+fun TrendingCoin.toEntity() = TrendingCoinEntity(
+    id = id,
+    symbol = symbol,
+    name = name,
+    image = image
+)

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/di/DataModule.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/di/DataModule.kt
@@ -1,6 +1,9 @@
 package com.rafaellsdev.cryptocurrencyprices.di
 
 import com.rafaellsdev.cryptocurrencyprices.commons.const.URLs.BASE_URL
+import com.rafaellsdev.cryptocurrencyprices.commons.local.AppDatabase
+import com.rafaellsdev.cryptocurrencyprices.commons.local.CurrencyDao
+import com.rafaellsdev.cryptocurrencyprices.commons.local.TrendingCoinDao
 import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.CurrencyRepository
 import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.CurrencyRepositoryImp
 import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.TrendingRepository
@@ -19,6 +22,8 @@ import com.rafaellsdev.cryptocurrencyprices.commons.currency.CurrencyPreferenceR
 import com.rafaellsdev.cryptocurrencyprices.commons.favorites.FavoritesRepository
 import com.rafaellsdev.cryptocurrencyprices.commons.favorites.FavoritesRepositoryImp
 import android.content.SharedPreferences
+import com.rafaellsdev.cryptocurrencyprices.BaseApplication
+import androidx.room.Room
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -30,6 +35,21 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object DataModule {
+
+    @Singleton
+    @Provides
+    fun provideDatabase(app: BaseApplication): AppDatabase =
+        Room.databaseBuilder(app, AppDatabase::class.java, "prices.db").build()
+
+    @Singleton
+    @Provides
+    fun provideCurrencyDao(database: AppDatabase): CurrencyDao =
+        database.currencyDao()
+
+    @Singleton
+    @Provides
+    fun provideTrendingCoinDao(database: AppDatabase): TrendingCoinDao =
+        database.trendingCoinDao()
 
     @Singleton
     @Provides
@@ -63,9 +83,10 @@ object DataModule {
     @Provides
     fun provideDiscoverRepository(
         discoverService: DiscoverService,
-        currencyPreferenceRepository: CurrencyPreferenceRepository
+        currencyPreferenceRepository: CurrencyPreferenceRepository,
+        currencyDao: CurrencyDao
     ): CurrencyRepository =
-        CurrencyRepositoryImp(discoverService, currencyPreferenceRepository)
+        CurrencyRepositoryImp(discoverService, currencyPreferenceRepository, currencyDao)
 
     @Singleton
     @Provides
@@ -74,8 +95,11 @@ object DataModule {
 
     @Singleton
     @Provides
-    fun provideTrendingRepository(trendingService: TrendingService): TrendingRepository =
-        TrendingRepositoryImp(trendingService)
+    fun provideTrendingRepository(
+        trendingService: TrendingService,
+        trendingCoinDao: TrendingCoinDao
+    ): TrendingRepository =
+        TrendingRepositoryImp(trendingService, trendingCoinDao)
 
     @Singleton
     @Provides

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CurrencyRepositoryImp.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CurrencyRepositoryImp.kt
@@ -1,23 +1,39 @@
 package com.rafaellsdev.cryptocurrencyprices.feature.home.repository
 
 import com.rafaellsdev.cryptocurrencyprices.commons.model.Currency
+import com.rafaellsdev.cryptocurrencyprices.commons.local.CurrencyDao
+import com.rafaellsdev.cryptocurrencyprices.commons.local.toDomain
+import com.rafaellsdev.cryptocurrencyprices.commons.local.toEntity
 import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.mapper.toCurrencyList
 import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.service.DiscoverService
 import com.rafaellsdev.cryptocurrencyprices.commons.currency.CurrencyPreferenceRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
 import javax.inject.Inject
 
 class CurrencyRepositoryImp @Inject constructor(
     private val discoverService: DiscoverService,
-    private val currencyPreferenceRepository: CurrencyPreferenceRepository
+    private val currencyPreferenceRepository: CurrencyPreferenceRepository,
+    private val currencyDao: CurrencyDao
 ) : CurrencyRepository {
     override suspend fun discoverCurrencies(category: String?): List<Currency> =
         withContext(Dispatchers.IO) {
             val currency = currencyPreferenceRepository.getSelectedCurrency()
-            discoverService.discoverCurrencies(
-                currency = currency,
-                category = category
-            ).toCurrencyList()
+            try {
+                val result = discoverService.discoverCurrencies(
+                    currency = currency,
+                    category = category
+                ).toCurrencyList()
+                currencyDao.insertCurrencies(result.map { it.toEntity() })
+                result
+            } catch (e: Exception) {
+                if (e is IOException || (e is HttpException && e.code() == 429)) {
+                    currencyDao.getCurrencies().map { it.toDomain() }
+                } else {
+                    throw e
+                }
+            }
         }
 }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/TrendingRepositoryImp.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/TrendingRepositoryImp.kt
@@ -1,17 +1,33 @@
 package com.rafaellsdev.cryptocurrencyprices.feature.home.repository
 
 import com.rafaellsdev.cryptocurrencyprices.commons.model.TrendingCoin
+import com.rafaellsdev.cryptocurrencyprices.commons.local.TrendingCoinDao
+import com.rafaellsdev.cryptocurrencyprices.commons.local.toDomain
+import com.rafaellsdev.cryptocurrencyprices.commons.local.toEntity
 import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.mapper.toTrendingCoinList
 import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.service.TrendingService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
 import javax.inject.Inject
 
 class TrendingRepositoryImp @Inject constructor(
-    private val service: TrendingService
+    private val service: TrendingService,
+    private val trendingCoinDao: TrendingCoinDao
 ) : TrendingRepository {
     override suspend fun getTrendingCoins(): List<TrendingCoin> =
         withContext(Dispatchers.IO) {
-            service.getTrendingCoins().toTrendingCoinList()
+            try {
+                val result = service.getTrendingCoins().toTrendingCoinList()
+                trendingCoinDao.insertTrendingCoins(result.map { it.toEntity() })
+                result
+            } catch (e: Exception) {
+                if (e is IOException || (e is HttpException && e.code() == 429)) {
+                    trendingCoinDao.getTrendingCoins().map { it.toDomain() }
+                } else {
+                    throw e
+                }
+            }
         }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     ext.kotlin_version = '1.9.21'
     ext.hilt_version = '2.48'
+    ext.room_version = '2.6.1'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Summary
- add Room database and DAOs
- store currencies and trending coins locally
- fallback to cached data on network error or HTTP 429

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c18165648327b029bfe42a894e8b