### PR TITLE
Add favorite coins home screen widget

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,21 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <receiver
+            android:name="com.rafaellsdev.cryptocurrencyprices.feature.widget.FavoriteCoinsWidgetProvider"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/favorite_coins_widget_info" />
+        </receiver>
+
+        <service
+            android:name="com.rafaellsdev.cryptocurrencyprices.feature.widget.FavoriteCoinsWidgetService"
+            android:permission="android.permission.BIND_REMOTEVIEWS" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/local/CurrencyDao.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/commons/local/CurrencyDao.kt
@@ -10,6 +10,9 @@ interface CurrencyDao {
     @Query("SELECT * FROM currencies")
     suspend fun getCurrencies(): List<CurrencyEntity>
 
+    @Query("SELECT * FROM currencies WHERE id IN (:ids)")
+    suspend fun getCurrenciesByIds(ids: List<String>): List<CurrencyEntity>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertCurrencies(currencies: List<CurrencyEntity>)
 }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CurrencyRepository.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CurrencyRepository.kt
@@ -4,4 +4,6 @@ import com.rafaellsdev.cryptocurrencyprices.commons.model.Currency
 
 interface CurrencyRepository {
     suspend fun discoverCurrencies(category: String? = null): List<Currency>
+
+    suspend fun getCurrenciesByIds(ids: List<String>): List<Currency>
 }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CurrencyRepositoryImp.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/CurrencyRepositoryImp.kt
@@ -36,4 +36,17 @@ class CurrencyRepositoryImp @Inject constructor(
                 }
             }
         }
+
+    override suspend fun getCurrenciesByIds(ids: List<String>): List<Currency> =
+        withContext(Dispatchers.IO) {
+            val currency = currencyPreferenceRepository.getSelectedCurrency()
+            val idParam = ids.joinToString(",")
+            try {
+                discoverService.getCurrenciesByIds(currency = currency, ids = idParam)
+                    .toCurrencyList()
+            } catch (e: Exception) {
+                val local = currencyDao.getCurrenciesByIds(ids).map { it.toDomain() }
+                if (local.isNotEmpty()) local else throw e
+            }
+        }
 }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/service/DiscoverService.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/home/repository/service/DiscoverService.kt
@@ -15,4 +15,11 @@ interface DiscoverService {
         @Query("sparkline") sparkline: Boolean = false,
         @Query("category") category: String? = null
     ): List<CurrencyResponse>
+
+    @GET(CURRENCIES_SERVICE)
+    suspend fun getCurrenciesByIds(
+        @Query("vs_currency") currency: String,
+        @Query("ids") ids: String,
+        @Query("sparkline") sparkline: Boolean = false
+    ): List<CurrencyResponse>
 }

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/widget/FavoriteCoinsRemoteViewsFactory.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/widget/FavoriteCoinsRemoteViewsFactory.kt
@@ -1,0 +1,50 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.widget
+
+import android.content.Context
+import android.widget.RemoteViews
+import android.widget.RemoteViewsService
+import com.rafaellsdev.cryptocurrencyprices.R
+import com.rafaellsdev.cryptocurrencyprices.commons.model.Currency
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.CurrencyRepository
+import com.rafaellsdev.cryptocurrencyprices.commons.favorites.FavoritesRepository
+import kotlinx.coroutines.runBlocking
+
+class FavoriteCoinsRemoteViewsFactory(
+    private val context: Context,
+    private val currencyRepository: CurrencyRepository,
+    private val favoritesRepository: FavoritesRepository
+) : RemoteViewsService.RemoteViewsFactory {
+
+    private var currencies: List<Currency> = emptyList()
+
+    override fun onCreate() {}
+
+    override fun onDataSetChanged() {
+        val ids = favoritesRepository.getFavorites().toList()
+        currencies = if (ids.isNotEmpty()) {
+            runBlocking { currencyRepository.getCurrenciesByIds(ids) }
+        } else {
+            emptyList()
+        }
+    }
+
+    override fun onDestroy() {}
+
+    override fun getCount(): Int = currencies.size
+
+    override fun getViewAt(position: Int): RemoteViews {
+        val currency = currencies[position]
+        return RemoteViews(context.packageName, R.layout.widget_favorite_coin_item).apply {
+            setTextViewText(R.id.txt_widget_coin_name, currency.symbol.uppercase())
+            setTextViewText(R.id.txt_widget_coin_price, currency.currentPrice.toString())
+        }
+    }
+
+    override fun getLoadingView(): RemoteViews? = null
+
+    override fun getViewTypeCount(): Int = 1
+
+    override fun getItemId(position: Int): Long = position.toLong()
+
+    override fun hasStableIds(): Boolean = true
+}

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/widget/FavoriteCoinsWidgetProvider.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/widget/FavoriteCoinsWidgetProvider.kt
@@ -1,0 +1,23 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.widget
+
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.Context
+import android.content.Intent
+import android.widget.RemoteViews
+import com.rafaellsdev.cryptocurrencyprices.R
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class FavoriteCoinsWidgetProvider : AppWidgetProvider() {
+
+    override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
+        for (widgetId in appWidgetIds) {
+            val intent = Intent(context, FavoriteCoinsWidgetService::class.java)
+            val views = RemoteViews(context.packageName, R.layout.widget_favorite_coins)
+            views.setRemoteAdapter(R.id.widget_list, intent)
+            views.setEmptyView(R.id.widget_list, R.id.widget_empty)
+            appWidgetManager.updateAppWidget(widgetId, views)
+        }
+    }
+}

--- a/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/widget/FavoriteCoinsWidgetService.kt
+++ b/app/src/main/java/com/rafaellsdev/cryptocurrencyprices/feature/widget/FavoriteCoinsWidgetService.kt
@@ -1,0 +1,19 @@
+package com.rafaellsdev.cryptocurrencyprices.feature.widget
+
+import android.content.Intent
+import android.widget.RemoteViewsService
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import com.rafaellsdev.cryptocurrencyprices.feature.home.repository.CurrencyRepository
+import com.rafaellsdev.cryptocurrencyprices.commons.favorites.FavoritesRepository
+
+@AndroidEntryPoint
+class FavoriteCoinsWidgetService : RemoteViewsService() {
+
+    @Inject lateinit var currencyRepository: CurrencyRepository
+    @Inject lateinit var favoritesRepository: FavoritesRepository
+
+    override fun onGetViewFactory(intent: Intent): RemoteViewsFactory {
+        return FavoriteCoinsRemoteViewsFactory(applicationContext, currencyRepository, favoritesRepository)
+    }
+}

--- a/app/src/main/res/layout/widget_favorite_coin_item.xml
+++ b/app/src/main/res/layout/widget_favorite_coin_item.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="4dp">
+
+    <TextView
+        android:id="@+id/txt_widget_coin_name"
+        android:layout_width="0dp"
+        android:layout_weight="1"
+        android:layout_height="wrap_content"
+        android:textColor="@android:color/black"
+        android:textSize="14sp"/>
+
+    <TextView
+        android:id="@+id/txt_widget_coin_price"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@android:color/black"
+        android:textSize="14sp"/>
+</LinearLayout>

--- a/app/src/main/res/layout/widget_favorite_coins.xml
+++ b/app/src/main/res/layout/widget_favorite_coins.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="8dp">
+
+    <ListView
+        android:id="@+id/widget_list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:divider="@android:color/transparent"/>
+
+    <TextView
+        android:id="@+id/widget_empty"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/no_favorites"
+        android:gravity="center"
+        android:visibility="gone"/>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,4 +37,5 @@
     <string name="total_market_cap">Total Market Cap</string>
     <string name="total_volume">Total Volume</string>
     <string name="market_dominance">Dominance</string>
+    <string name="no_favorites">No favorites selected</string>
 </resources>

--- a/app/src/main/res/xml/favorite_coins_widget_info.xml
+++ b/app/src/main/res/xml/favorite_coins_widget_info.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="250dp"
+    android:minHeight="110dp"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/widget_favorite_coins"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen">
+</appwidget-provider>


### PR DESCRIPTION
## Summary
- allow database queries for coins by ID
- expose `getCurrenciesByIds` in `CurrencyRepository`
- implement remote call `getCurrenciesByIds`
- create widget provider, service and remote views factory
- add widget layouts and manifest entries
- add user-facing string for empty favorites list

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840dfea3ccc832783db44a63b9c6401